### PR TITLE
Render daemon example adaptations during daemon add

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Key safety defaults:
 - existing destination directories/files require `--force`;
 - deprecated examples require `--allow-deprecated`;
 - add/install/show always surface `adaptationsRequired[]` in JSON;
+- add/install render documented `{{adapt.key}}` tokens from `--adapt key=value` and `--adapt-file` inputs (defaults < file < flags), validating `DAEMON.md` before any writes;
 - scaffolding does not activate a daemon until the change is merged and ingested by Charlie.
 
 See [Daemon catalog CLI](docs/daemon-cli.md) for command details, JSON envelope, validation semantics, and exit codes.

--- a/docs/daemon-cli.md
+++ b/docs/daemon-cli.md
@@ -73,6 +73,7 @@ Shows catalog details for one example:
 - required and optional integrations
 - support files from `scripts[]` and `references[]`
 - required adaptation notes from `adaptation.mustCustomize`
+- structured adaptation inputs from `adaptations[]` (key, label, required/optional, default, suggestions)
 - the activation caveat
 
 ```bash
@@ -81,7 +82,7 @@ daemon show pr-metadata
 daemon show pr-metadata --json
 ```
 
-`show` always returns `data.adaptationsRequired[]` in JSON, including for `adapt-before-use` examples. No explicit acknowledgement flag is required; the adaptation list is prominent in both human and JSON output.
+`show` always returns `data.adaptationsRequired[]` in JSON, including for `adapt-before-use` examples. No explicit acknowledgement flag is required; the adaptation list is prominent in both human and JSON output. When an example declares structured `adaptations[]`, `show` also returns `data.adaptations[]` describing each token key the CLI can render.
 
 ### `daemon add <example-id>` / `daemon install <example-id>`
 
@@ -123,12 +124,49 @@ daemon add js-ts-dependency-upgrades --force
 JSON data includes:
 
 - `adaptationsRequired[]`
+- `adaptationsApplied[]` — the adaptation keys whose values were rendered into the scaffolded files
 - `activationRequired`
 - `filesPlanned[]`, where each item includes `sourcePath`, `destinationPath`, `kind`, and `mode` (`100644` or `100755`)
 - `filesWritten[]`
 - `collisions[]`
 - `deprecatedBlocked`
 - `sourceRef`
+
+### Adaptation rendering
+
+Examples that declare structured `adaptations[]` embed `{{adapt.key}}` tokens in `DAEMON.md` and support files. `add`/`install` resolve values for those keys, render the tokens, and validate the rendered `DAEMON.md` before writing anything.
+
+Provide values two ways. Both are optional and can be combined:
+
+```bash
+# Repeated flags
+daemon add some-example --adapt repo=acme/web --adapt base_branch=main
+
+# A JSON object of string values
+daemon add some-example --adapt-file ./adaptations.json
+```
+
+`--adapt-file` must point at a JSON object whose values are all strings, for example:
+
+```json
+{ "repo": "acme/web", "base_branch": "main" }
+```
+
+Values are merged deterministically, lowest to highest precedence:
+
+1. optional adaptation defaults declared in the catalog
+2. `--adapt-file` values
+3. repeated `--adapt key=value` flags (later flags override earlier ones for the same key)
+
+`add`/`install` fail closed (exit code `65`, or `64` for malformed flags) without writing files when:
+
+- a required adaptation has no provided value
+- an input key (flag or file) is not declared by the example
+- a flag is not `key=value`, a key does not match `^[a-z][a-z0-9_]*$`, or a file value is not a string
+- a file or `DAEMON.md` contains a malformed `{{adapt.…}}` token, an undeclared token key, or a token left without a value
+- the rendered `DAEMON.md` fails runtime validation
+
+`--dry-run` performs the same resolution, rendering, and validation so failures surface before a real install.
 
 Scaffolding does **not** activate a daemon. The daemon becomes eligible only after the change is merged to the target repository default branch and Charlie ingests that merged version.
 

--- a/src/daemon-cli/__tests__/adaptations.test.ts
+++ b/src/daemon-cli/__tests__/adaptations.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from 'vitest';
+import {
+  knownAdaptationKeys,
+  parseAdaptFileContent,
+  parseAdaptFlags,
+  renderAdaptationTokens,
+  resolveAdaptations,
+  type AdaptationValues,
+} from '../adaptations';
+import type { CatalogExample, ExampleAdaptation } from '../../examples/types';
+
+function exampleWithAdaptations(adaptations: ExampleAdaptation[]): CatalogExample {
+  return {
+    id: 'sample',
+    title: 'Sample',
+    status: 'ready',
+    summary: 'A sample example.',
+    readiness: 'adapt-before-use',
+    showOnWebsite: true,
+    showInDashboard: true,
+    fit: { jobsToBeDone: ['operate'], bestFor: ['tests'], notFor: ['prod'] },
+    requirements: { requiredIntegrations: ['github'], optionalIntegrations: [], other: [] },
+    adaptation: { mustCustomize: ['Customize me.'] },
+    adaptations,
+    daemon: { path: 'DAEMON.md', content: '---\nid: sample\n---\nbody' },
+    scripts: [],
+    references: [],
+    source: {
+      directory: 'daemons/sample',
+      url: 'https://github.com/charlie-labs/daemons/tree/master/daemons/sample',
+    },
+  };
+}
+
+function values(record: Record<string, string>): AdaptationValues {
+  return new Map(Object.entries(record));
+}
+
+describe('parseAdaptFlags', () => {
+  test('parses key=value pairs and lets later flags win', () => {
+    const result = parseAdaptFlags(['repo=acme/web', 'repo=acme/api', 'base_branch=main']);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(Object.fromEntries(result.values)).toEqual({ repo: 'acme/api', base_branch: 'main' });
+  });
+
+  test('keeps values that contain = signs intact', () => {
+    const result = parseAdaptFlags(['filter=type==bug']);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.values.get('filter')).toBe('type==bug');
+  });
+
+  test('rejects flags without key=value syntax', () => {
+    const result = parseAdaptFlags(['oops', '=value']);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.errors.map((error) => error.code)).toEqual(['ADAPT_FLAG_INVALID', 'ADAPT_FLAG_INVALID']);
+  });
+
+  test('rejects keys that do not match the key pattern', () => {
+    const result = parseAdaptFlags(['Repo=acme']);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.errors[0]?.code).toBe('ADAPTATION_KEY_INVALID');
+  });
+});
+
+describe('parseAdaptFileContent', () => {
+  test('parses a JSON object of string values', () => {
+    const result = parseAdaptFileContent({ content: '{"repo":"acme/web","base_branch":"main"}', path: 'adapt.json' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(Object.fromEntries(result.values)).toEqual({ repo: 'acme/web', base_branch: 'main' });
+  });
+
+  test('rejects invalid JSON', () => {
+    const result = parseAdaptFileContent({ content: '{not json', path: 'adapt.json' });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.errors[0]?.code).toBe('ADAPT_FILE_JSON_INVALID');
+  });
+
+  test('rejects non-object JSON', () => {
+    const result = parseAdaptFileContent({ content: '["a"]', path: 'adapt.json' });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.errors[0]?.code).toBe('ADAPT_FILE_INVALID_TYPE');
+  });
+
+  test('rejects non-string values', () => {
+    const result = parseAdaptFileContent({ content: '{"repo": 5, "flag": true}', path: 'adapt.json' });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.errors.map((error) => error.code)).toEqual([
+      'ADAPT_FILE_VALUE_INVALID_TYPE',
+      'ADAPT_FILE_VALUE_INVALID_TYPE',
+    ]);
+  });
+});
+
+describe('resolveAdaptations', () => {
+  const entry = exampleWithAdaptations([
+    { key: 'repo', label: 'Repository', description: 'Target repo', required: true },
+    { key: 'base_branch', label: 'Base branch', description: 'Default branch', required: false, default: 'main' },
+  ]);
+
+  test('applies defaults < file < cli precedence', () => {
+    const result = resolveAdaptations({
+      entry,
+      fileValues: values({ repo: 'acme/from-file', base_branch: 'develop' }),
+      cliValues: values({ repo: 'acme/from-cli' }),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(Object.fromEntries(result.resolution.values)).toEqual({
+      repo: 'acme/from-cli',
+      base_branch: 'develop',
+    });
+    expect(result.resolution.appliedKeys).toEqual(['base_branch', 'repo']);
+  });
+
+  test('falls back to the optional default when no value is provided', () => {
+    const result = resolveAdaptations({
+      entry,
+      fileValues: values({}),
+      cliValues: values({ repo: 'acme/web' }),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.resolution.values.get('base_branch')).toBe('main');
+  });
+
+  test('rejects missing required values', () => {
+    const result = resolveAdaptations({ entry, fileValues: values({}), cliValues: values({}) });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.errors.map((error) => error.code)).toContain('MISSING_REQUIRED_ADAPTATION');
+  });
+
+  test('rejects unknown input keys from file and flags', () => {
+    const result = resolveAdaptations({
+      entry,
+      fileValues: values({ mystery: 'x' }),
+      cliValues: values({ repo: 'acme/web', other: 'y' }),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    const codes = result.errors.map((error) => error.code);
+    expect(codes.filter((code) => code === 'UNKNOWN_ADAPTATION_INPUT_KEY')).toHaveLength(2);
+  });
+});
+
+describe('renderAdaptationTokens', () => {
+  const knownKeys = knownAdaptationKeys(
+    exampleWithAdaptations([{ key: 'repo', label: 'Repo', description: 'd', required: true }])
+  );
+
+  test('replaces declared tokens with provided values', () => {
+    const result = renderAdaptationTokens({
+      content: 'Repo is {{adapt.repo}} and {{ adapt.repo }}.',
+      values: values({ repo: 'acme/web' }),
+      knownKeys,
+      path: 'DAEMON.md',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.content).toBe('Repo is acme/web and acme/web.');
+  });
+
+  test('leaves non-adaptation mustache tokens untouched', () => {
+    const result = renderAdaptationTokens({
+      content: 'Keep {{other.thing}} as-is, set {{adapt.repo}}.',
+      values: values({ repo: 'acme/web' }),
+      knownKeys,
+      path: 'DAEMON.md',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.content).toBe('Keep {{other.thing}} as-is, set acme/web.');
+  });
+
+  test('rejects malformed adaptation tokens', () => {
+    const result = renderAdaptationTokens({
+      content: 'Bad {{adapt.Repo}} token.',
+      values: values({ repo: 'acme/web' }),
+      knownKeys,
+      path: 'DAEMON.md',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.errors[0]?.code).toBe('MALFORMED_ADAPTATION_TOKEN');
+  });
+
+  test('rejects unknown token keys', () => {
+    const result = renderAdaptationTokens({
+      content: 'Unknown {{adapt.mystery}}.',
+      values: values({ repo: 'acme/web' }),
+      knownKeys,
+      path: 'DAEMON.md',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.errors[0]?.code).toBe('UNKNOWN_ADAPTATION_TOKEN');
+  });
+
+  test('rejects declared tokens that have no resolved value', () => {
+    const result = renderAdaptationTokens({
+      content: 'Needs {{adapt.repo}}.',
+      values: values({}),
+      knownKeys,
+      path: 'DAEMON.md',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.errors[0]?.code).toBe('MISSING_ADAPTATION_TOKEN_VALUE');
+  });
+});

--- a/src/daemon-cli/__tests__/cli.test.ts
+++ b/src/daemon-cli/__tests__/cli.test.ts
@@ -362,6 +362,213 @@ describe('daemon CLI catalog commands', () => {
   });
 });
 
+const adaptiveDaemon = `---
+id: adaptive-daemon
+purpose: Keep {{adapt.repo}} tidy.
+watch:
+  - when a pull request changes files under src/
+routines:
+  - inspect the change on {{adapt.base_branch}} and report findings
+deny:
+  - do not merge pull requests
+---
+
+# Adaptive daemon
+
+Target repo {{adapt.repo}} on base branch {{adapt.base_branch}}.
+`;
+
+const adaptiveReference = '# Setup\n\nConfigure {{adapt.repo}} before enabling.\n';
+
+const undeclaredTokenDaemon = `---
+id: bad-token-daemon
+purpose: Watch {{adapt.ghost}}.
+watch:
+  - when something changes
+routines:
+  - do a bounded thing
+deny:
+  - do not mutate prod
+---
+
+# Bad token daemon
+
+Uses an undeclared {{adapt.ghost}} token.
+`;
+
+const adaptiveCatalog: ExamplesCatalog = {
+  schemaVersion: 1,
+  source: { repository: 'charlie-labs/daemons', baseDirectory: 'daemons' },
+  examples: [
+    {
+      id: 'adaptive-daemon',
+      title: 'Adaptive daemon',
+      status: 'ready',
+      summary: 'An adaptation fixture.',
+      readiness: 'adapt-before-use',
+      showOnWebsite: true,
+      showInDashboard: true,
+      fit: { jobsToBeDone: ['operate'], bestFor: ['tests'], notFor: ['prod'] },
+      requirements: { requiredIntegrations: ['github'], optionalIntegrations: [], other: [] },
+      adaptation: { mustCustomize: ['Set the repo.'] },
+      adaptations: [
+        { key: 'base_branch', label: 'Base branch', description: 'Default branch', required: false, default: 'main' },
+        { key: 'repo', label: 'Repository', description: 'Target repository', required: true },
+      ],
+      daemon: { path: 'DAEMON.md', content: adaptiveDaemon },
+      scripts: [],
+      references: ['references/setup.md'],
+      source: {
+        directory: 'daemons/adaptive-daemon',
+        url: 'https://github.com/charlie-labs/daemons/tree/master/daemons/adaptive-daemon',
+      },
+    },
+    {
+      id: 'bad-token-daemon',
+      title: 'Bad token daemon',
+      status: 'ready',
+      summary: 'A daemon with an undeclared token.',
+      readiness: 'adapt-before-use',
+      showOnWebsite: true,
+      showInDashboard: true,
+      fit: { jobsToBeDone: ['operate'], bestFor: ['tests'], notFor: ['prod'] },
+      requirements: { requiredIntegrations: ['github'], optionalIntegrations: [], other: [] },
+      adaptation: { mustCustomize: ['Fix the token.'] },
+      adaptations: [],
+      daemon: { path: 'DAEMON.md', content: undeclaredTokenDaemon },
+      scripts: [],
+      references: [],
+      source: {
+        directory: 'daemons/bad-token-daemon',
+        url: 'https://github.com/charlie-labs/daemons/tree/master/daemons/bad-token-daemon',
+      },
+    },
+  ],
+};
+
+function adaptiveCatalogClient(): CatalogClient {
+  const files = new Map<string, string>([
+    ['master:daemons/adaptive-daemon/references/setup.md', adaptiveReference],
+  ]);
+  return {
+    async loadCatalog(): Promise<ExamplesCatalog> {
+      return adaptiveCatalog;
+    },
+    async readTextFile(ref: string, filePath: string): Promise<string> {
+      const value = files.get(`${ref}:${filePath}`);
+      if (value === undefined) {
+        throw new Error(`missing mock file ${ref}:${filePath}`);
+      }
+      return value;
+    },
+  };
+}
+
+describe('daemon CLI adaptation rendering', () => {
+  test('install renders declared tokens in DAEMON.md and support files', async () => {
+    await withTempDir(async (directory) => {
+      const result = await runJson(
+        ['install', 'adaptive-daemon', '--adapt', 'repo=acme/web', '--adapt', 'base_branch=develop'],
+        directory,
+        adaptiveCatalogClient()
+      );
+
+      expect(result.code).toBe(0);
+      expect(result.json.data.adaptationsApplied).toEqual(['base_branch', 'repo']);
+
+      const daemon = await readFile(path.join(directory, '.agents/daemons/adaptive-daemon/DAEMON.md'), 'utf8');
+      expect(daemon).toContain('purpose: Keep acme/web tidy.');
+      expect(daemon).toContain('Target repo acme/web on base branch develop.');
+      expect(daemon).not.toContain('{{');
+
+      const reference = await readFile(path.join(directory, '.agents/daemons/adaptive-daemon/references/setup.md'), 'utf8');
+      expect(reference).toContain('Configure acme/web before enabling.');
+      expect(reference).not.toContain('{{');
+    });
+  });
+
+  test('optional adaptation falls back to its default when omitted', async () => {
+    await withTempDir(async (directory) => {
+      const result = await runJson(['install', 'adaptive-daemon', '--adapt', 'repo=acme/web'], directory, adaptiveCatalogClient());
+
+      expect(result.code).toBe(0);
+      const daemon = await readFile(path.join(directory, '.agents/daemons/adaptive-daemon/DAEMON.md'), 'utf8');
+      expect(daemon).toContain('on base branch main.');
+    });
+  });
+
+  test('--adapt flags override --adapt-file values', async () => {
+    await withTempDir(async (directory) => {
+      const adaptFile = path.join(directory, 'adapt.json');
+      await writeFile(adaptFile, JSON.stringify({ repo: 'acme/from-file', base_branch: 'from-file' }), 'utf8');
+
+      const result = await runJson(
+        ['install', 'adaptive-daemon', '--adapt-file', 'adapt.json', '--adapt', 'repo=acme/from-cli'],
+        directory,
+        adaptiveCatalogClient()
+      );
+
+      expect(result.code).toBe(0);
+      const daemon = await readFile(path.join(directory, '.agents/daemons/adaptive-daemon/DAEMON.md'), 'utf8');
+      expect(daemon).toContain('Keep acme/from-cli tidy.');
+      expect(daemon).toContain('on base branch from-file.');
+    });
+  });
+
+  test('dry-run resolves and validates without writing files', async () => {
+    await withTempDir(async (directory) => {
+      const result = await runJson(['add', 'adaptive-daemon', '--dry-run', '--adapt', 'repo=acme/web'], directory, adaptiveCatalogClient());
+
+      expect(result.code).toBe(0);
+      expect(result.json.data.adaptationsApplied).toEqual(['base_branch', 'repo']);
+      expect(result.json.data.filesWritten).toEqual([]);
+      await expect(readFile(path.join(directory, '.agents/daemons/adaptive-daemon/DAEMON.md'), 'utf8')).rejects.toThrow();
+    });
+  });
+
+  test('missing required adaptation fails closed without writing files', async () => {
+    await withTempDir(async (directory) => {
+      const result = await runJson(['add', 'adaptive-daemon'], directory, adaptiveCatalogClient());
+
+      expect(result.code).toBe(65);
+      expect(result.json.errors.map((error: { code: string }) => error.code)).toContain('MISSING_REQUIRED_ADAPTATION');
+      await expect(readFile(path.join(directory, '.agents/daemons/adaptive-daemon/DAEMON.md'), 'utf8')).rejects.toThrow();
+    });
+  });
+
+  test('unknown input keys are rejected', async () => {
+    await withTempDir(async (directory) => {
+      const result = await runJson(
+        ['add', 'adaptive-daemon', '--adapt', 'repo=acme/web', '--adapt', 'mystery=value'],
+        directory,
+        adaptiveCatalogClient()
+      );
+
+      expect(result.code).toBe(65);
+      expect(result.json.errors.map((error: { code: string }) => error.code)).toContain('UNKNOWN_ADAPTATION_INPUT_KEY');
+    });
+  });
+
+  test('malformed --adapt flags are a usage error', async () => {
+    await withTempDir(async (directory) => {
+      const result = await runJson(['add', 'adaptive-daemon', '--adapt', 'oops'], directory, adaptiveCatalogClient());
+
+      expect(result.code).toBe(64);
+      expect(result.json.errors[0].code).toBe('ADAPT_FLAG_INVALID');
+    });
+  });
+
+  test('undeclared tokens in catalog content fail at render time', async () => {
+    await withTempDir(async (directory) => {
+      const result = await runJson(['add', 'bad-token-daemon'], directory, adaptiveCatalogClient());
+
+      expect(result.code).toBe(65);
+      expect(result.json.errors.map((error: { code: string }) => error.code)).toContain('UNKNOWN_ADAPTATION_TOKEN');
+      await expect(readFile(path.join(directory, '.agents/daemons/bad-token-daemon/DAEMON.md'), 'utf8')).rejects.toThrow();
+    });
+  });
+});
+
 describe('daemon CLI validation', () => {
   test('validate reports cron, unknown key, body, and slug errors with exit 65', async () => {
     await withTempDir(async (directory) => {

--- a/src/daemon-cli/adaptations.ts
+++ b/src/daemon-cli/adaptations.ts
@@ -1,0 +1,370 @@
+import { issue } from './issues';
+import type { CliIssue } from './types';
+import type { CatalogExample, ExampleAdaptation } from '../examples/types';
+
+export const ADAPTATION_KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
+const MUSTACHE_TOKEN_PATTERN = /{{\s*([^{}]*?)\s*}}/g;
+const ADAPTATION_EXPRESSION_PREFIX_PATTERN = /^adapt(?:$|[.\s])/;
+const ADAPTATION_TOKEN_EXPRESSION_PATTERN = /^adapt\.([a-z][a-z0-9_]*)$/;
+const ADAPTATION_TOKEN_PATTERN = /{{\s*adapt\.([a-z][a-z0-9_]*)\s*}}/g;
+const UNRESOLVED_ADAPTATION_TOKEN_PATTERN = /{{\s*adapt\.[^}]*}}/;
+
+export type AdaptationValues = Map<string, string>;
+
+export type AdaptationResolution = {
+  values: AdaptationValues;
+  appliedKeys: string[];
+};
+
+function sortedKeys(keys: Iterable<string>): string[] {
+  return [...keys].sort((left, right) => left.localeCompare(right));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function valueType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+function validateInputKey(args: {
+  key: string;
+  field: string;
+  path?: string | null | undefined;
+  errors: CliIssue[];
+}): void {
+  if (!ADAPTATION_KEY_PATTERN.test(args.key)) {
+    args.errors.push(
+      issue({
+        code: 'ADAPTATION_KEY_INVALID',
+        message: `Adaptation key '${args.key}' must match ^[a-z][a-z0-9_]*$.`,
+        field: args.field,
+        path: args.path ?? null,
+      })
+    );
+  }
+}
+
+/**
+ * Parse repeated `--adapt key=value` flags. Later occurrences of the same key
+ * win so callers can override earlier values on the command line.
+ */
+export function parseAdaptFlags(flagValues: readonly string[] | undefined):
+  | { ok: true; values: AdaptationValues }
+  | { ok: false; errors: CliIssue[] } {
+  const values: AdaptationValues = new Map();
+  const errors: CliIssue[] = [];
+
+  for (const [index, rawValue] of (flagValues ?? []).entries()) {
+    const field = `adapt[${index.toString()}]`;
+    const separatorIndex = rawValue.indexOf('=');
+    if (separatorIndex <= 0) {
+      errors.push(
+        issue({
+          code: 'ADAPT_FLAG_INVALID',
+          message: 'Adaptation flags must use --adapt key=value syntax.',
+          field,
+        })
+      );
+      continue;
+    }
+
+    const key = rawValue.slice(0, separatorIndex);
+    const value = rawValue.slice(separatorIndex + 1);
+    validateInputKey({ key, field, errors });
+    values.set(key, value);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+  return { ok: true, values };
+}
+
+/**
+ * Parse an `--adapt-file` JSON object of string values. Rejects non-objects,
+ * non-string values, and invalid keys.
+ */
+export function parseAdaptFileContent(args: { content: string; path: string }):
+  | { ok: true; values: AdaptationValues }
+  | { ok: false; errors: CliIssue[] } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(args.content);
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [
+        issue({
+          code: 'ADAPT_FILE_JSON_INVALID',
+          message: error instanceof Error ? error.message : 'Adaptation file must contain valid JSON.',
+          path: args.path,
+        }),
+      ],
+    };
+  }
+
+  if (!isRecord(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        issue({
+          code: 'ADAPT_FILE_INVALID_TYPE',
+          message: 'Adaptation file must contain a JSON object of string values.',
+          path: args.path,
+        }),
+      ],
+    };
+  }
+
+  const values: AdaptationValues = new Map();
+  const errors: CliIssue[] = [];
+  for (const key of sortedKeys(Object.keys(parsed))) {
+    validateInputKey({ key, field: key, path: args.path, errors });
+    const value = parsed[key];
+    if (typeof value !== 'string') {
+      errors.push(
+        issue({
+          code: 'ADAPT_FILE_VALUE_INVALID_TYPE',
+          message: `Adaptation file value for '${key}' must be a string, not ${valueType(value)}.`,
+          field: key,
+          path: args.path,
+        })
+      );
+      continue;
+    }
+    values.set(key, value);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+  return { ok: true, values };
+}
+
+function metadataByKey(adaptations: readonly ExampleAdaptation[]):
+  | { ok: true; byKey: Map<string, ExampleAdaptation> }
+  | { ok: false; errors: CliIssue[] } {
+  const byKey = new Map<string, ExampleAdaptation>();
+  const errors: CliIssue[] = [];
+
+  for (const [index, adaptation] of adaptations.entries()) {
+    if (byKey.has(adaptation.key)) {
+      errors.push(
+        issue({
+          code: 'CATALOG_ADAPTATION_DUPLICATE_KEY',
+          message: `Catalog adaptation key '${adaptation.key}' is duplicated.`,
+          field: `adaptations[${index.toString()}].key`,
+        })
+      );
+      continue;
+    }
+    byKey.set(adaptation.key, adaptation);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+  return { ok: true, byKey };
+}
+
+function validateUnknownInputKeys(args: {
+  values: AdaptationValues;
+  knownKeys: ReadonlySet<string>;
+  path?: string | null | undefined;
+}): CliIssue[] {
+  const errors: CliIssue[] = [];
+  for (const key of sortedKeys(args.values.keys())) {
+    if (!args.knownKeys.has(key)) {
+      errors.push(
+        issue({
+          code: 'UNKNOWN_ADAPTATION_INPUT_KEY',
+          message: `Unknown adaptation input key '${key}'.`,
+          field: key,
+          path: args.path ?? null,
+        })
+      );
+    }
+  }
+  return errors;
+}
+
+/**
+ * Merge adaptation values deterministically: optional defaults are the base
+ * layer, file values override defaults, and CLI flag values override both.
+ * Rejects unknown input keys and missing required values.
+ */
+export function resolveAdaptations(args: {
+  entry: CatalogExample;
+  fileValues: AdaptationValues;
+  cliValues: AdaptationValues;
+  filePath?: string | null | undefined;
+}): { ok: true; resolution: AdaptationResolution } | { ok: false; errors: CliIssue[] } {
+  const metadataResult = metadataByKey(args.entry.adaptations ?? []);
+  if (!metadataResult.ok) {
+    return metadataResult;
+  }
+
+  const byKey = metadataResult.byKey;
+  const knownKeys = new Set(byKey.keys());
+  const errors: CliIssue[] = [
+    ...validateUnknownInputKeys({ values: args.fileValues, knownKeys, path: args.filePath }),
+    ...validateUnknownInputKeys({ values: args.cliValues, knownKeys }),
+  ];
+
+  const values: AdaptationValues = new Map();
+  for (const key of sortedKeys(byKey.keys())) {
+    const adaptation = byKey.get(key)!;
+    if (adaptation.required) {
+      if (adaptation.default !== undefined) {
+        errors.push(
+          issue({
+            code: 'CATALOG_REQUIRED_ADAPTATION_HAS_DEFAULT',
+            message: `Catalog required adaptation '${key}' must not declare a default.`,
+            field: key,
+          })
+        );
+      }
+      continue;
+    }
+
+    if (adaptation.default === undefined) {
+      errors.push(
+        issue({
+          code: 'CATALOG_OPTIONAL_ADAPTATION_MISSING_DEFAULT',
+          message: `Catalog optional adaptation '${key}' must declare a default.`,
+          field: key,
+        })
+      );
+      continue;
+    }
+
+    values.set(key, adaptation.default);
+  }
+
+  for (const key of sortedKeys(args.fileValues.keys())) {
+    const value = args.fileValues.get(key)!;
+    if (knownKeys.has(key)) values.set(key, value);
+  }
+
+  for (const [key, value] of args.cliValues.entries()) {
+    if (knownKeys.has(key)) values.set(key, value);
+  }
+
+  for (const key of sortedKeys(byKey.keys())) {
+    const adaptation = byKey.get(key)!;
+    if (adaptation.required && !values.has(key)) {
+      errors.push(
+        issue({
+          code: 'MISSING_REQUIRED_ADAPTATION',
+          message: `Missing required adaptation '${key}'. Provide it with --adapt ${key}=... or --adapt-file.`,
+          field: key,
+        })
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    resolution: {
+      values,
+      appliedKeys: sortedKeys(values.keys()),
+    },
+  };
+}
+
+/**
+ * Replace `{{adapt.key}}` tokens with resolved values. Rejects malformed
+ * tokens, tokens whose key is not declared in the catalog, and tokens without
+ * a resolved value before any content is rewritten.
+ */
+export function renderAdaptationTokens(args: {
+  content: string;
+  values: AdaptationValues;
+  knownKeys: ReadonlySet<string>;
+  path: string;
+}): { ok: true; content: string } | { ok: false; errors: CliIssue[] } {
+  const errors: CliIssue[] = [];
+  const reportedMalformedTokens = new Set<string>();
+
+  for (const token of args.content.matchAll(MUSTACHE_TOKEN_PATTERN)) {
+    const rawExpression = token[1] ?? '';
+    const expression = rawExpression.trim();
+    if (!ADAPTATION_EXPRESSION_PREFIX_PATTERN.test(expression)) {
+      continue;
+    }
+
+    const expressionMatch = ADAPTATION_TOKEN_EXPRESSION_PATTERN.exec(expression);
+    if (!expressionMatch) {
+      const renderedToken = token[0] ?? `{{${rawExpression}}}`;
+      if (reportedMalformedTokens.has(renderedToken)) {
+        continue;
+      }
+
+      reportedMalformedTokens.add(renderedToken);
+      errors.push(
+        issue({
+          code: 'MALFORMED_ADAPTATION_TOKEN',
+          message: `Malformed adaptation token '${renderedToken}'. Use '{{adapt.key}}' with a key matching ^[a-z][a-z0-9_]*$.`,
+          path: args.path,
+        })
+      );
+      continue;
+    }
+
+    const key = expressionMatch[1] ?? '';
+    if (!args.knownKeys.has(key)) {
+      errors.push(
+        issue({
+          code: 'UNKNOWN_ADAPTATION_TOKEN',
+          message: `Unknown adaptation token '${key}'.`,
+          field: key,
+          path: args.path,
+        })
+      );
+      continue;
+    }
+
+    if (!args.values.has(key)) {
+      errors.push(
+        issue({
+          code: 'MISSING_ADAPTATION_TOKEN_VALUE',
+          message: `No value was provided for adaptation token '${key}'.`,
+          field: key,
+          path: args.path,
+        })
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const rendered = args.content.replace(ADAPTATION_TOKEN_PATTERN, (_match, rawKey: string) => args.values.get(rawKey) ?? '');
+  if (UNRESOLVED_ADAPTATION_TOKEN_PATTERN.test(rendered)) {
+    return {
+      ok: false,
+      errors: [
+        issue({
+          code: 'UNRESOLVED_ADAPTATION_TOKEN',
+          message: 'Rendered content still contains an adaptation token.',
+          path: args.path,
+        }),
+      ],
+    };
+  }
+
+  return { ok: true, content: rendered };
+}
+
+export function knownAdaptationKeys(entry: CatalogExample): ReadonlySet<string> {
+  return new Set((entry.adaptations ?? []).map((adaptation) => adaptation.key));
+}

--- a/src/daemon-cli/cli.ts
+++ b/src/daemon-cli/cli.ts
@@ -176,6 +176,16 @@ function formatHumanResult(result: CliCommandResult, verbose: boolean): string {
     } else {
       for (const adaptation of adaptations) lines.push(`- ${String(adaptation)}`);
     }
+    const structuredAdaptations = Array.isArray(data.adaptations) ? data.adaptations : [];
+    if (structuredAdaptations.length > 0) {
+      lines.push('Adaptation inputs:');
+      for (const adaptation of structuredAdaptations) {
+        if (typeof adaptation === 'object' && adaptation !== null && 'key' in adaptation) {
+          const record = adaptation as Record<string, unknown>;
+          lines.push(`- ${String(record.key)} (${record.required === true ? 'required' : 'optional'}): ${String(record.label)}`);
+        }
+      }
+    }
     lines.push(`Activation: ${String(data.activationRequired)}`);
   }
 
@@ -191,6 +201,13 @@ function formatHumanResult(result: CliCommandResult, verbose: boolean): string {
       lines.push('- none declared');
     } else {
       for (const adaptation of adaptations) lines.push(`- ${String(adaptation)}`);
+    }
+    const appliedKeys = Array.isArray(data.adaptationsApplied) ? data.adaptationsApplied : [];
+    lines.push('Adaptation keys applied:');
+    if (appliedKeys.length === 0) {
+      lines.push('- none');
+    } else {
+      for (const key of appliedKeys) lines.push(`- ${String(key)}`);
     }
     lines.push(`Activation: ${String(data.activationRequired)}`);
   }

--- a/src/daemon-cli/commands.ts
+++ b/src/daemon-cli/commands.ts
@@ -22,6 +22,14 @@ import {
   toDisplayPath,
   writeTextFileEnsuringDirectory,
 } from './fs-utils';
+import {
+  knownAdaptationKeys,
+  parseAdaptFileContent,
+  parseAdaptFlags,
+  renderAdaptationTokens,
+  resolveAdaptations,
+  type AdaptationResolution,
+} from './adaptations';
 import { createDaemonInstallPlan } from './install-plan';
 import { issue, normalizeErrorMessage } from './issues';
 import type {
@@ -46,6 +54,18 @@ function usageResult(command: string, summary: string): CliCommandResult {
     summary,
     warnings: [],
     errors: [issue({ code: 'USAGE_ERROR', message: summary })],
+    data: null,
+  };
+}
+
+function usageIssuesResult(command: string, summary: string, errors: CliIssue[]): CliCommandResult {
+  return {
+    command,
+    ok: false,
+    exitCode: EXIT_CODE_USAGE,
+    summary,
+    warnings: [],
+    errors,
     data: null,
   };
 }
@@ -204,6 +224,7 @@ export async function runShowCommand(args: {
         sourceDirectory: entry.source.directory,
         sourceUrl: entry.source.url,
         adaptationsRequired: adaptationsFor(entry),
+        adaptations: [...(entry.adaptations ?? [])],
         activationRequired: ACTIVATION_CAVEAT,
       },
     };
@@ -234,6 +255,7 @@ function addDataForBlocked(args: {
   force: boolean;
   collisions: string[];
   deprecatedBlocked: boolean;
+  adaptationsApplied?: string[] | undefined;
 }): AddData {
   const destinationDirectory = path.join(args.installRoot, DEFAULT_DAEMON_ROOT, args.entry.id);
   return {
@@ -250,6 +272,7 @@ function addDataForBlocked(args: {
     status: args.entry.status,
     readiness: args.entry.readiness,
     adaptationsRequired: adaptationsFor(args.entry),
+    adaptationsApplied: args.adaptationsApplied ?? [],
     activationRequired: ACTIVATION_CAVEAT,
     filesPlanned: args.files.map((file) => ({
       ...file,
@@ -259,6 +282,108 @@ function addDataForBlocked(args: {
     collisions: args.collisions,
     deprecatedBlocked: args.deprecatedBlocked,
   };
+}
+
+type RenderedInstallFile = InstallFilePlan & {
+  content: string;
+};
+
+function dataErrorResult<TData>(command: string, summary: string, errors: CliIssue[], data: TData | null): CliCommandResult<TData> {
+  return {
+    command,
+    ok: false,
+    exitCode: EXIT_CODE_DATA,
+    summary,
+    warnings: [],
+    errors,
+    data,
+  };
+}
+
+async function loadAdaptFileValues(args: { cwd: string; adaptFile: string | undefined }): Promise<
+  | { ok: true; fileValues: Map<string, string>; displayPath: string | null }
+  | { ok: false; errors: CliIssue[] }
+> {
+  if (!args.adaptFile) {
+    return { ok: true, fileValues: new Map(), displayPath: null };
+  }
+
+  const absolutePath = path.resolve(args.cwd, args.adaptFile);
+  const displayPath = toDisplayPath(args.cwd, absolutePath);
+  try {
+    const content = await readUtf8File(absolutePath);
+    const parsed = parseAdaptFileContent({ content, path: displayPath });
+    if (!parsed.ok) {
+      return { ok: false, errors: parsed.errors };
+    }
+    return { ok: true, fileValues: parsed.values, displayPath };
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [issue({ code: 'ADAPT_FILE_READ_FAILED', message: normalizeErrorMessage(error), path: displayPath })],
+    };
+  }
+}
+
+/**
+ * Render adaptation tokens into every planned file, then validate the rendered
+ * DAEMON.md before any writes happen. Rendering and validation run for both
+ * dry runs and real installs so failures surface consistently.
+ */
+async function renderInstallFiles(args: {
+  entry: CatalogExample;
+  ref: string;
+  catalogClient: CatalogClient;
+  installRoot: string;
+  files: readonly InstallFilePlan[];
+  resolution: AdaptationResolution;
+}): Promise<{ ok: true; files: RenderedInstallFile[] } | { ok: false; errors: CliIssue[] }> {
+  const renderedFiles: RenderedInstallFile[] = [];
+  const errors: CliIssue[] = [];
+  const knownKeys = knownAdaptationKeys(args.entry);
+
+  for (const file of args.files) {
+    const content =
+      file.kind === 'daemon'
+        ? args.entry.daemon.content
+        : await args.catalogClient.readTextFile(args.ref, file.sourcePath);
+    const displayPath = toDisplayPath(args.installRoot, file.destinationPath);
+    const rendered = renderAdaptationTokens({
+      content,
+      values: args.resolution.values,
+      knownKeys,
+      path: displayPath,
+    });
+    if (!rendered.ok) {
+      errors.push(...rendered.errors);
+      continue;
+    }
+    renderedFiles.push({ ...file, content: rendered.content });
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const daemonFile = renderedFiles.find((file) => file.kind === 'daemon');
+  if (!daemonFile) {
+    return {
+      ok: false,
+      errors: [issue({ code: 'INSTALL_PLAN_MISSING_DAEMON', message: 'Install plan did not include DAEMON.md.' })],
+    };
+  }
+
+  const daemonDisplayPath = toDisplayPath(args.installRoot, daemonFile.destinationPath);
+  const validation = validateRuntimeDaemonMarkdown({
+    content: daemonFile.content,
+    path: daemonDisplayPath,
+    expectedId: expectedDaemonIdFromPath(daemonDisplayPath),
+  });
+  if (!validation.ok) {
+    return { ok: false, errors: validation.errors };
+  }
+
+  return { ok: true, files: renderedFiles };
 }
 
 export async function runAddCommand(args: {
@@ -276,6 +401,8 @@ export async function runAddCommand(args: {
         force: { type: 'boolean', default: false },
         'dry-run': { type: 'boolean', default: false },
         'allow-deprecated': { type: 'boolean', default: false },
+        adapt: { type: 'string', multiple: true },
+        'adapt-file': { type: 'string' },
       },
       allowPositionals: true,
       strict: true,
@@ -297,6 +424,11 @@ export async function runAddCommand(args: {
   const force = parsed.values.force === true;
   const dryRun = parsed.values['dry-run'] === true;
   const allowDeprecated = parsed.values['allow-deprecated'] === true;
+  const adaptFile = parsed.values['adapt-file'];
+  const parsedAdaptFlags = parseAdaptFlags(parsed.values.adapt);
+  if (!parsedAdaptFlags.ok) {
+    return usageIssuesResult(args.commandName, 'Invalid adaptation flags.', parsedAdaptFlags.errors) as CliCommandResult<AddData>;
+  }
 
   try {
     const [catalog, installRoot] = await Promise.all([
@@ -356,18 +488,66 @@ export async function runAddCommand(args: {
       };
     }
 
+    const fileValues = await loadAdaptFileValues({ cwd: args.cwd, adaptFile });
+    if (!fileValues.ok) {
+      return dataErrorResult(
+        args.commandName,
+        'Unable to read adaptation inputs.',
+        fileValues.errors,
+        addDataForBlocked({ entry, ref, installRoot, files: installPlan.files, dryRun, force, collisions, deprecatedBlocked: false })
+      );
+    }
+
+    const adaptationResolution = resolveAdaptations({
+      entry,
+      fileValues: fileValues.fileValues,
+      cliValues: parsedAdaptFlags.values,
+      filePath: fileValues.displayPath,
+    });
+    if (!adaptationResolution.ok) {
+      return dataErrorResult(
+        args.commandName,
+        `Adaptation inputs for '${exampleId}' are incomplete or invalid.`,
+        adaptationResolution.errors,
+        addDataForBlocked({ entry, ref, installRoot, files: installPlan.files, dryRun, force, collisions, deprecatedBlocked: false })
+      );
+    }
+
+    const rendered = await renderInstallFiles({
+      entry,
+      ref,
+      catalogClient: args.catalogClient,
+      installRoot,
+      files: installPlan.files,
+      resolution: adaptationResolution.resolution,
+    });
+    if (!rendered.ok) {
+      return dataErrorResult(
+        args.commandName,
+        `Rendered daemon example '${exampleId}' is invalid.`,
+        rendered.errors,
+        addDataForBlocked({
+          entry,
+          ref,
+          installRoot,
+          files: installPlan.files,
+          dryRun,
+          force,
+          collisions,
+          deprecatedBlocked: false,
+          adaptationsApplied: adaptationResolution.resolution.appliedKeys,
+        })
+      );
+    }
+
     const filesWritten: string[] = [];
 
     if (!dryRun) {
       await mkdir(destinationDirectory, { recursive: true });
-      for (const file of installPlan.files) {
-        const content =
-          file.kind === 'daemon'
-            ? entry.daemon.content
-            : await args.catalogClient.readTextFile(ref, file.sourcePath);
+      for (const file of rendered.files) {
         await writeTextFileEnsuringDirectory({
           path: file.destinationPath,
-          content,
+          content: file.content,
           mode: file.mode,
         });
         filesWritten.push(toDisplayPath(installRoot, file.destinationPath));
@@ -388,6 +568,7 @@ export async function runAddCommand(args: {
       status: entry.status,
       readiness: entry.readiness,
       adaptationsRequired: adaptationsFor(entry),
+      adaptationsApplied: adaptationResolution.resolution.appliedKeys,
       activationRequired: ACTIVATION_CAVEAT,
       filesPlanned: installPlan.files.map((file) => ({ ...file, destinationPath: toDisplayPath(installRoot, file.destinationPath) })),
       filesWritten,
@@ -400,8 +581,8 @@ export async function runAddCommand(args: {
       ok: true,
       exitCode: EXIT_CODE_SUCCESS,
       summary: dryRun
-        ? `Dry run: would scaffold '${entry.id}' into ${data.filePath}. Adaptation required before use.`
-        : `Scaffolded '${entry.id}' into ${data.filePath}. Adaptation required before use; daemon is not active yet.`,
+        ? `Dry run: would scaffold '${entry.id}' into ${data.filePath}. Applied ${data.adaptationsApplied.length.toString()} adaptation key${data.adaptationsApplied.length === 1 ? '' : 's'}.`
+        : `Scaffolded '${entry.id}' into ${data.filePath}. Applied ${data.adaptationsApplied.length.toString()} adaptation key${data.adaptationsApplied.length === 1 ? '' : 's'}; daemon is not active yet.`,
       warnings: [],
       errors: [],
       data,

--- a/src/daemon-cli/help.ts
+++ b/src/daemon-cli/help.ts
@@ -4,7 +4,7 @@ export function getRootHelpText(): string {
 Usage:
   daemon list [--ref <sha|branch|tag>] [--json]
   daemon show <example-id> [--ref <sha|branch|tag>] [--json]
-  daemon add <example-id> [--ref <sha|branch|tag>] [--dry-run] [--force] [--allow-deprecated] [--json]
+  daemon add <example-id> [--ref <sha|branch|tag>] [--adapt key=value] [--adapt-file adaptations.json] [--dry-run] [--force] [--allow-deprecated] [--json]
   daemon install <example-id> [same flags as add]
   daemon validate <path> [--dry-run] [--json]
   daemon validate --all [--dry-run] [--json]
@@ -22,11 +22,11 @@ export function getCommandHelpText(command: string): string {
   }
 
   if (command === 'show') {
-    return 'Usage: daemon show <example-id> [--ref <sha|branch|tag>] [--json]\n\nShows catalog metadata, support files, integrations, and required adaptations.';
+    return 'Usage: daemon show <example-id> [--ref <sha|branch|tag>] [--json]\n\nShows catalog metadata, support files, integrations, required adaptations, and structured adaptation inputs.';
   }
 
   if (command === 'add') {
-    return 'Usage: daemon add <example-id> [--ref <sha|branch|tag>] [--dry-run] [--force] [--allow-deprecated] [--json]\n\nScaffolds catalog-listed files into .agents/daemons/<id>/ without activating the daemon.';
+    return 'Usage: daemon add <example-id> [--ref <sha|branch|tag>] [--adapt key=value] [--adapt-file adaptations.json] [--dry-run] [--force] [--allow-deprecated] [--json]\n\nScaffolds catalog-listed files into .agents/daemons/<id>/ without activating the daemon. Adaptation values render documented {{adapt.key}} tokens, then DAEMON.md is validated before any writes.';
   }
 
   if (command === 'validate') {

--- a/src/daemon-cli/types.ts
+++ b/src/daemon-cli/types.ts
@@ -1,4 +1,4 @@
-import type { CatalogExample, ExamplesCatalog } from '../examples/types';
+import type { CatalogExample, ExampleAdaptation, ExamplesCatalog } from '../examples/types';
 
 export type CliIssue = {
   code: string;
@@ -51,6 +51,7 @@ export type ShowData = CatalogListItem & {
   sourceDirectory: string;
   sourceUrl: string;
   adaptationsRequired: string[];
+  adaptations: ExampleAdaptation[];
   activationRequired: string;
 };
 
@@ -77,6 +78,7 @@ export type AddData = {
   status: CatalogExample['status'];
   readiness: CatalogExample['readiness'];
   adaptationsRequired: string[];
+  adaptationsApplied: string[];
   activationRequired: string;
   filesPlanned: InstallFilePlan[];
   filesWritten: string[];

--- a/src/daemon-examples.ts
+++ b/src/daemon-examples.ts
@@ -2,9 +2,10 @@ import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseExamplesCatalogContent } from './examples/schema';
-import type { CatalogExample, ExamplesCatalog, ValidationError } from './examples/types';
+import type { CatalogExample, ExampleAdaptation, ExamplesCatalog, ValidationError } from './examples/types';
 
 export type DaemonExample = CatalogExample;
+export type DaemonExampleAdaptation = ExampleAdaptation;
 export type DaemonExamplesCatalog = ExamplesCatalog;
 
 export type LoadDaemonExamplesCatalogOptions = {

--- a/src/examples/__tests__/adaptations-schema.test.ts
+++ b/src/examples/__tests__/adaptations-schema.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'vitest';
+import { parseExampleYaml } from '../schema';
+
+const BASE_YAML = `id: sample-daemon
+title: Sample daemon
+status: ready
+summary: A sample daemon for adaptation schema tests.
+readiness: adapt-before-use
+showOnWebsite: true
+showInDashboard: true
+fit:
+  jobsToBeDone:
+    - operate
+  bestFor:
+    - Repositories used in tests.
+  notFor:
+    - Production without edits.
+requirements:
+  requiredIntegrations:
+    - github
+  optionalIntegrations: []
+  other: []
+adaptation:
+  mustCustomize:
+    - Set the repository.
+`;
+
+function withAdaptations(adaptationsYaml: string): string {
+  return `${BASE_YAML}adaptations:\n${adaptationsYaml}`;
+}
+
+describe('example.yml adaptations schema', () => {
+  test('accepts well-formed required and optional adaptations', () => {
+    const result = parseExampleYaml({
+      content: withAdaptations(
+        `  - key: repo
+    label: Repository
+    description: Target repository.
+    required: true
+  - key: base_branch
+    label: Base branch
+    description: Default branch.
+    required: false
+    default: main
+    suggestions:
+      - main
+      - develop
+`
+      ),
+      path: 'example.yml',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value.adaptations).toHaveLength(2);
+  });
+
+  test('omitting adaptations is allowed', () => {
+    const result = parseExampleYaml({ content: BASE_YAML, path: 'example.yml' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value.adaptations).toBeUndefined();
+  });
+
+  test('rejects required adaptations that declare a default', () => {
+    const result = parseExampleYaml({
+      content: withAdaptations(
+        `  - key: repo
+    label: Repository
+    description: Target repository.
+    required: true
+    default: acme/web
+`
+      ),
+      path: 'example.yml',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects optional adaptations without a default', () => {
+    const result = parseExampleYaml({
+      content: withAdaptations(
+        `  - key: base_branch
+    label: Base branch
+    description: Default branch.
+    required: false
+`
+      ),
+      path: 'example.yml',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects invalid adaptation keys', () => {
+    const result = parseExampleYaml({
+      content: withAdaptations(
+        `  - key: Repo
+    label: Repository
+    description: Target repository.
+    required: true
+`
+      ),
+      path: 'example.yml',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects duplicate adaptation keys', () => {
+    const result = parseExampleYaml({
+      content: withAdaptations(
+        `  - key: repo
+    label: Repository
+    description: Target repository.
+    required: true
+  - key: repo
+    label: Repository again
+    description: Duplicate key.
+    required: true
+`
+      ),
+      path: 'example.yml',
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/examples/catalog.ts
+++ b/src/examples/catalog.ts
@@ -7,6 +7,7 @@ import { parseDaemonMarkdown, parseExampleYaml } from './schema';
 import type {
   CatalogExample,
   DaemonPackage,
+  ExampleAdaptation,
   ExampleMetadata,
   ExamplesCatalog,
   ValidationError,
@@ -19,6 +20,19 @@ const SOURCE_BASE_DIRECTORY = 'daemons';
 const DEFAULT_PUBLICATION_REF = 'master';
 const ROOT_CATALOG_PATH = 'examples.json';
 const ALLOWED_DAEMON_PACKAGE_ENTRIES = new Set(['DAEMON.md', 'example.yml', 'scripts', 'references']);
+
+function catalogAdaptations(adaptations: readonly ExampleAdaptation[]): ExampleAdaptation[] {
+  return [...adaptations]
+    .sort((left, right) => left.key.localeCompare(right.key))
+    .map((adaptation) => ({
+      key: adaptation.key,
+      label: adaptation.label,
+      description: adaptation.description,
+      required: adaptation.required,
+      ...(adaptation.default !== undefined ? { default: adaptation.default } : {}),
+      ...(adaptation.suggestions !== undefined ? { suggestions: [...adaptation.suggestions] } : {}),
+    }));
+}
 
 export async function generateCatalogFromRepository(
   repoRoot: string,
@@ -310,6 +324,9 @@ async function loadCatalogExample(
       adaptation: {
         mustCustomize: exampleMetadata.adaptation.mustCustomize,
       },
+      ...(exampleMetadata.adaptations && exampleMetadata.adaptations.length > 0
+        ? { adaptations: catalogAdaptations(exampleMetadata.adaptations) }
+        : {}),
       daemon: {
         path: 'DAEMON.md',
         content: daemonContent.value,

--- a/src/examples/schema.ts
+++ b/src/examples/schema.ts
@@ -39,6 +39,53 @@ const jobToBeDoneSchema = z.enum([
 
 const integrationSchema = z.enum(['github', 'linear', 'slack', 'sentry']);
 
+export const ADAPTATION_KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+const adaptationKeySchema = z.string().refine((value) => ADAPTATION_KEY_PATTERN.test(value), {
+  message: 'Expected an adaptation key matching ^[a-z][a-z0-9_]*$.',
+});
+
+const adaptationSchema = z
+  .object({
+    key: adaptationKeySchema,
+    label: nonEmptyStringSchema,
+    description: nonEmptyStringSchema,
+    required: z.boolean(),
+    default: nonEmptyStringSchema.optional(),
+    suggestions: z.array(nonEmptyStringSchema).min(1).optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.required && value.default !== undefined) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['default'],
+        message: 'Required adaptations must not declare a default.',
+      });
+    }
+    if (!value.required && value.default === undefined) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['default'],
+        message: 'Optional adaptations must declare a default.',
+      });
+    }
+  });
+
+const adaptationsSchema = z.array(adaptationSchema).superRefine((value, context) => {
+  const seen = new Set<string>();
+  for (const [index, adaptation] of value.entries()) {
+    if (seen.has(adaptation.key)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [index, 'key'],
+        message: `Duplicate adaptation key ${adaptation.key}.`,
+      });
+    }
+    seen.add(adaptation.key);
+  }
+});
+
 const exampleMetadataSchema = z
   .object({
     id: slugSchema,
@@ -67,6 +114,7 @@ const exampleMetadataSchema = z
         mustCustomize: stringListSchema,
       })
       .strict(),
+    adaptations: adaptationsSchema.optional(),
   })
   .strict()
   .superRefine((value, context) => {
@@ -145,6 +193,7 @@ const catalogExampleSchema: z.ZodType<CatalogExample> = z
         mustCustomize: stringListSchema,
       })
       .strict(),
+    adaptations: adaptationsSchema.optional(),
     daemon: z
       .object({
         path: z.literal('DAEMON.md'),

--- a/src/examples/types.ts
+++ b/src/examples/types.ts
@@ -30,6 +30,15 @@ export type JobToBeDone =
   | 'daemon-operations';
 export type IntegrationSlug = 'github' | 'linear' | 'slack' | 'sentry';
 
+export type ExampleAdaptation = {
+  key: string;
+  label: string;
+  description: string;
+  required: boolean;
+  default?: string | undefined;
+  suggestions?: string[] | undefined;
+};
+
 export type ExampleMetadata = {
   id: string;
   title: string;
@@ -51,6 +60,7 @@ export type ExampleMetadata = {
   adaptation: {
     mustCustomize: string[];
   };
+  adaptations?: ExampleAdaptation[] | undefined;
 };
 
 export type CatalogExample = ExampleMetadata & {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
 } from './daemon-examples';
 export type {
   DaemonExample,
+  DaemonExampleAdaptation,
   DaemonExamplesCatalog,
   LoadDaemonExamplesCatalogOptions,
 } from './daemon-examples';


### PR DESCRIPTION
Adds adaptation-token rendering to `daemon add`/`install` so examples can ship `{{adapt.key}}` placeholders that are filled in at scaffold time.

## What's new
- **`--adapt key=value`** (repeatable) and **`--adapt-file adaptations.json`** (JSON object of string values) inputs.
- Deterministic merge: optional catalog defaults < file values < repeated flags (later flags win per key).
- Renders `{{adapt.key}}` tokens in `DAEMON.md` and support files, then runs the existing runtime validation on the rendered `DAEMON.md` **before any writes** (dry runs validate too).
- Fails closed on missing required values, unknown input keys, non-string file values, malformed flags, and malformed/unknown/unresolved tokens. Applied keys are reported via `adaptationsApplied[]`.

## Scope note
This consumes a structured `adaptations[]` example contract (BOT-11371). Since that schema work isn't on `master` yet, this PR adds it **additively and minimally**: `adaptations[]` is an optional field, the legacy `adaptation.mustCustomize` and `schemaVersion: 1` are preserved, and no example declares adaptations yet — so `examples.json` is byte-for-byte unchanged. The broader metadata/catalog redesign stays with BOT-11371.

## Validation
- `typecheck` ✅
- `test` ✅ (58 tests, +31 for adaptation parsing/merge/rendering/failure paths/generated files)
- `generate:examples` + `git diff --exit-code examples.json` ✅ (unchanged)
- `validate:examples` ✅
- `build` ✅ and manual `node dist/bin.js` checks (help text, `--adapt` resolution, unknown-key failure)
- `smoke:daemon` not run here — it shells out to `bun pm pack`, and `bun` isn't available in this environment; the `node dist/bin.js` portion passed.
